### PR TITLE
Fix sign-in redirection loop issue

### DIFF
--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -95,8 +95,26 @@ function SignInContent() {
       }
 
       // Redirect to dashboard or return URL
-      const returnUrl = searchParams.get("returnUrl") || "/dashboard";
-      router.push(returnUrl);
+      // searchParams.get() automatically decodes URL-encoded values
+      const returnUrlParam = searchParams.get("returnUrl");
+      let returnUrl = "/dashboard";
+
+      if (returnUrlParam) {
+        // Ensure it's properly decoded (searchParams.get should handle this, but be safe)
+        try {
+          returnUrl = decodeURIComponent(returnUrlParam);
+          // Validate that it's a valid path (starts with /)
+          if (!returnUrl.startsWith("/")) {
+            returnUrl = "/dashboard";
+          }
+        } catch {
+          // If decoding fails, use default
+          returnUrl = "/dashboard";
+        }
+      }
+
+      // Use replace to avoid adding sign-in page to browser history
+      router.replace(returnUrl);
     } catch (err: unknown) {
       const errorMessage =
         err instanceof Error ? err.message : "Sign in failed";

--- a/app/dashboard/chat_page/page.tsx
+++ b/app/dashboard/chat_page/page.tsx
@@ -93,10 +93,12 @@ export default function PDFChatterPage() {
   };
 
   useEffect(() => {
-    const storedToken = localStorage.getItem("token");
+    // Check for access_token first (new system), then fall back to token (old system)
+    const storedToken =
+      localStorage.getItem("access_token") || localStorage.getItem("token");
 
     if (!storedToken) {
-      router.push("/login");
+      router.push("/auth/sign-in");
       return;
     }
 
@@ -174,10 +176,13 @@ export default function PDFChatterPage() {
   };
 
   const handleLogout = () => {
+    // Clear both old and new token keys
+    localStorage.removeItem("access_token");
+    localStorage.removeItem("refresh_token");
     localStorage.removeItem("token");
     localStorage.removeItem("username");
     localStorage.removeItem("tokenType");
-    router.push("/login");
+    router.push("/auth/sign-in");
   };
 
   const validateFiles = (files: File[]) => {

--- a/app/dashboard/flashcards/page.tsx
+++ b/app/dashboard/flashcards/page.tsx
@@ -39,18 +39,23 @@ export default function FlashcardsPage() {
   const [username, setUsername] = useState("");
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
+    // Check for access_token first (new system), then fall back to token (old system)
+    const token =
+      localStorage.getItem("access_token") || localStorage.getItem("token");
     if (!token) {
-      router.push("/login");
+      router.push("/auth/sign-in");
       return;
     }
 
     const handleLogout = () => {
+      // Clear both old and new token keys
+      localStorage.removeItem("access_token");
+      localStorage.removeItem("refresh_token");
       localStorage.removeItem("token");
       localStorage.removeItem("username");
       localStorage.removeItem("tokenType");
       localStorage.removeItem("userId");
-      router.push("/login");
+      router.push("/auth/sign-in");
     };
 
     const initializeData = async () => {

--- a/app/dashboard/notes/page.tsx
+++ b/app/dashboard/notes/page.tsx
@@ -107,9 +107,11 @@ export default function NotesPage() {
 
   // Check authentication
   useEffect(() => {
-    const token = localStorage.getItem("token");
+    // Check for access_token first (new system), then fall back to token (old system)
+    const token =
+      localStorage.getItem("access_token") || localStorage.getItem("token");
     if (!token) {
-      router.push("/login");
+      router.push("/auth/sign-in");
     } else {
       loadNotes();
       loadDocuments();

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -116,9 +116,11 @@ export default function Dashboard() {
   };
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
+    // Check for access_token first (new system), then fall back to token (old system)
+    const token =
+      localStorage.getItem("access_token") || localStorage.getItem("token");
     if (!token) {
-      router.push("/login");
+      router.push("/auth/sign-in");
       return;
     }
 
@@ -127,11 +129,14 @@ export default function Dashboard() {
   }, [router]);
 
   const handleLogout = () => {
+    // Clear both old and new token keys
+    localStorage.removeItem("access_token");
+    localStorage.removeItem("refresh_token");
     localStorage.removeItem("token");
     localStorage.removeItem("username");
     localStorage.removeItem("tokenType");
     localStorage.removeItem("userId");
-    router.push("/login");
+    router.push("/auth/sign-in");
   };
 
   const handleDeleteDocument = async (documentId: string) => {

--- a/app/dashboard/pdf_Reader/page.tsx
+++ b/app/dashboard/pdf_Reader/page.tsx
@@ -95,10 +95,11 @@ export default function PDFReaderPage() {
   const [pdfBlob, setPdfBlob] = useState<Blob | null>(null);
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const handleLogout = useCallback(() => {
+    // Clear both old and new token keys
     localStorage.removeItem("access_token");
     localStorage.removeItem("refresh_token");
     localStorage.removeItem("token");
-    router.push("/login");
+    router.push("/auth/sign-in");
   }, [router]);
 
   const initializeData = useCallback(async () => {
@@ -127,9 +128,11 @@ export default function PDFReaderPage() {
   }, [handleLogout]);
 
   useEffect(() => {
-    const token = localStorage.getItem("access_token");
+    // Check for access_token first (new system), then fall back to token (old system)
+    const token =
+      localStorage.getItem("access_token") || localStorage.getItem("token");
     if (!token) {
-      router.push("/login");
+      router.push("/auth/sign-in");
       return;
     }
 

--- a/app/dashboard/quizzes/[quizId]/attempt/[attemptId]/page.tsx
+++ b/app/dashboard/quizzes/[quizId]/attempt/[attemptId]/page.tsx
@@ -50,9 +50,11 @@ export default function QuizAttemptPage() {
   const startTimeRef = useRef<number>(Date.now());
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
+    // Check for access_token first (new system), then fall back to token (old system)
+    const token =
+      localStorage.getItem("access_token") || localStorage.getItem("token");
     if (!token) {
-      router.push("/login");
+      router.push("/auth/sign-in");
     } else if (quizId && attemptId) {
       loadQuizAndAttempt();
     }

--- a/app/dashboard/quizzes/[quizId]/attempt/[attemptId]/results/page.tsx
+++ b/app/dashboard/quizzes/[quizId]/attempt/[attemptId]/results/page.tsx
@@ -36,9 +36,11 @@ export default function QuizResultsPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
+    // Check for access_token first (new system), then fall back to token (old system)
+    const token =
+      localStorage.getItem("access_token") || localStorage.getItem("token");
     if (!token) {
-      router.push("/login");
+      router.push("/auth/sign-in");
     } else if (quizId && attemptId) {
       loadResults();
     }

--- a/app/dashboard/quizzes/[quizId]/page.tsx
+++ b/app/dashboard/quizzes/[quizId]/page.tsx
@@ -56,9 +56,11 @@ export default function QuizDetailPage() {
   }, [quizId]);
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
+    // Check for access_token first (new system), then fall back to token (old system)
+    const token =
+      localStorage.getItem("access_token") || localStorage.getItem("token");
     if (!token) {
-      router.push("/login");
+      router.push("/auth/sign-in");
     } else if (quizId) {
       loadQuiz();
     }

--- a/app/dashboard/quizzes/generate/page.tsx
+++ b/app/dashboard/quizzes/generate/page.tsx
@@ -41,9 +41,11 @@ export default function GenerateQuizPage() {
   const [streamMessage, setStreamMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
+    // Check for access_token first (new system), then fall back to token (old system)
+    const token =
+      localStorage.getItem("access_token") || localStorage.getItem("token");
     if (!token) {
-      router.push("/login");
+      router.push("/auth/sign-in");
     } else {
       loadDocuments();
     }

--- a/app/dashboard/quizzes/page.tsx
+++ b/app/dashboard/quizzes/page.tsx
@@ -43,9 +43,11 @@ export default function QuizzesPage() {
   };
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
+    // Check for access_token first (new system), then fall back to token (old system)
+    const token =
+      localStorage.getItem("access_token") || localStorage.getItem("token");
     if (!token) {
-      router.push("/login");
+      router.push("/auth/sign-in");
     } else {
       loadQuizzes();
     }


### PR DESCRIPTION
## Problem
After successful sign-in, users were being redirected to the dashboard but then immediately redirected back to the sign-in page, creating a redirect loop.

## Root Cause
The sign-in flow stores the authentication token as `access_token` in localStorage, but all dashboard pages were checking for the old `token` key. This caused:
1. Successful sign-in → token stored as `access_token`
2. Redirect to dashboard → dashboard checks for `token` → not found
3. Dashboard redirects back to sign-in → infinite loop

## Solution
- Updated all dashboard pages to check for `access_token` first, then fall back to `token` for backward compatibility
- Updated all redirect paths from `/login` to `/auth/sign-in` for consistency
- Enhanced logout functions to properly clear both new and old token keys

## Files Changed
- `app/dashboard/page.tsx`
- `app/dashboard/chat_page/page.tsx`
- `app/dashboard/flashcards/page.tsx`
- `app/dashboard/notes/page.tsx`
- `app/dashboard/quizzes/page.tsx`
- `app/dashboard/quizzes/generate/page.tsx`
- `app/dashboard/quizzes/[quizId]/page.tsx`
- `app/dashboard/quizzes/[quizId]/attempt/[attemptId]/page.tsx`
- `app/dashboard/quizzes/[quizId]/attempt/[attemptId]/results/page.tsx`
- `app/dashboard/pdf_Reader/page.tsx`
- `app/auth/sign-in/page.tsx` (improved returnUrl handling)

## Testing
✅ Sign-in now correctly redirects to dashboard
✅ Dashboard recognizes authenticated users
✅ No redirect loop after successful authentication
✅ Backward compatibility maintained for old token format